### PR TITLE
lib improvements

### DIFF
--- a/kbinxmlcs/BigEndianBinaryBuffer.cs
+++ b/kbinxmlcs/BigEndianBinaryBuffer.cs
@@ -1,27 +1,49 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 
 namespace kbinxmlcs
 {
     internal class BigEndianBinaryBuffer
     {
+        protected bool isRead;
         protected List<byte> Buffer;
-        protected int Offset;
+        protected byte[] Buffer_ro;
+        protected int Offset = 0;
 
         internal BigEndianBinaryBuffer(byte[] buffer)
         {
+            isRead = true;
+            Buffer_ro = buffer;
             Buffer = new List<byte>(buffer);
         }
 
         internal BigEndianBinaryBuffer()
         {
+            isRead = false;
             Buffer = new List<byte>();
         }
 
         internal virtual byte[] ReadBytes(int count)
         {
-            byte[] buffer = Buffer.Skip(Offset).Take(count).ToArray();
+            byte[] buffer;
+            if (isRead)
+            {
+                buffer = new byte[count];
+                System.Buffer.BlockCopy(Buffer_ro, Offset, buffer, 0, count);
+            }
+            else
+            {
+                if (count == 1)
+                {
+                    buffer = new byte[] { Buffer[Offset] };
+                }
+                else
+                {
+                    buffer = Buffer.Skip(Offset).Take(count).ToArray();
+                }
+            }
             Offset += count;
 
             return buffer;
@@ -29,6 +51,7 @@ namespace kbinxmlcs
 
         internal virtual void WriteBytes(byte[] buffer)
         {
+            if (isRead) throw new Exception("This binary buffer should only be read");
             Buffer.InsertRange(Offset, buffer);
             Offset += buffer.Length;
         }

--- a/kbinxmlcs/BigEndianBinaryBuffer.cs
+++ b/kbinxmlcs/BigEndianBinaryBuffer.cs
@@ -9,9 +9,15 @@ namespace kbinxmlcs
         protected List<byte> Buffer;
         protected int Offset;
 
-        internal BigEndianBinaryBuffer(byte[] buffer) => Buffer = new List<byte>(buffer);
+        internal BigEndianBinaryBuffer(byte[] buffer)
+        {
+            Buffer = new List<byte>(buffer);
+        }
 
-        internal BigEndianBinaryBuffer() => Buffer = new List<byte>();
+        internal BigEndianBinaryBuffer()
+        {
+            Buffer = new List<byte>();
+        }
 
         internal virtual byte[] ReadBytes(int count)
         {
@@ -27,37 +33,85 @@ namespace kbinxmlcs
             Offset += buffer.Length;
         }
 
-        internal virtual void WriteS8(sbyte value) => WriteBytes(new byte[] { (byte)value });
+        internal virtual void WriteS8(sbyte value)
+        {
+            WriteBytes(new byte[] { (byte)value });
+        }
 
-        internal virtual void WriteS16(short value) => WriteBytes(BitConverter.GetBytes(value).Reverse().ToArray());
+        internal virtual void WriteS16(short value)
+        {
+            WriteBytes(BitConverter.GetBytes(value).Reverse().ToArray());
+        }
 
-        internal virtual void WriteS32(int value) => WriteBytes(BitConverter.GetBytes(value).Reverse().ToArray());
+        internal virtual void WriteS32(int value)
+        {
+            WriteBytes(BitConverter.GetBytes(value).Reverse().ToArray());
+        }
 
-        internal virtual void WriteS64(long value) => WriteBytes(BitConverter.GetBytes(value).Reverse().ToArray());
+        internal virtual void WriteS64(long value)
+        {
+            WriteBytes(BitConverter.GetBytes(value).Reverse().ToArray());
+        }
 
-        internal virtual void WriteU8(byte value) => WriteBytes(new byte[] { value });
+        internal virtual void WriteU8(byte value)
+        {
+            WriteBytes(new byte[] { value });
+        }
 
-        internal virtual void WriteU16(ushort value) => WriteBytes(BitConverter.GetBytes(value).Reverse().ToArray());
+        internal virtual void WriteU16(ushort value)
+        {
+            WriteBytes(BitConverter.GetBytes(value).Reverse().ToArray());
+        }
 
-        internal virtual void WriteU32(uint value) => WriteBytes(BitConverter.GetBytes(value).Reverse().ToArray());
+        internal virtual void WriteU32(uint value)
+        {
+            WriteBytes(BitConverter.GetBytes(value).Reverse().ToArray());
+        }
 
-        internal virtual void WriteU64(ulong value) => WriteBytes(BitConverter.GetBytes(value).Reverse().ToArray());
+        internal virtual void WriteU64(ulong value)
+        {
+            WriteBytes(BitConverter.GetBytes(value).Reverse().ToArray());
+        }
 
-        internal virtual sbyte ReadS8() => (sbyte)ReadBytes(sizeof(byte))[0];
+        internal virtual sbyte ReadS8()
+        {
+            return (sbyte)ReadBytes(sizeof(byte))[0];
+        }
 
-        internal virtual short ReadS16() => BitConverter.ToInt16(ReadBytes(sizeof(short)).Reverse().ToArray());
+        internal virtual short ReadS16()
+        {
+            return BitConverter.ToInt16(ReadBytes(sizeof(short)).Reverse().ToArray(), 0);
+        }
 
-        internal virtual int ReadS32() => BitConverter.ToInt32(ReadBytes(sizeof(int)).Reverse().ToArray());
+        internal virtual int ReadS32()
+        {
+            return BitConverter.ToInt32(ReadBytes(sizeof(int)).Reverse().ToArray(), 0);
+        }
 
-        internal virtual long ReadS64() => BitConverter.ToInt64(ReadBytes(sizeof(long)).Reverse().ToArray());
+        internal virtual long ReadS64()
+        {
+            return BitConverter.ToInt64(ReadBytes(sizeof(long)).Reverse().ToArray(), 0);
+        }
 
-        internal virtual byte ReadU8() => ReadBytes(sizeof(byte))[0];
+        internal virtual byte ReadU8()
+        {
+            return ReadBytes(sizeof(byte))[0];
+        }
 
-        internal virtual ushort ReadU16() => BitConverter.ToUInt16(ReadBytes(sizeof(short)).Reverse().ToArray());
+        internal virtual ushort ReadU16()
+        {
+            return BitConverter.ToUInt16(ReadBytes(sizeof(short)).Reverse().ToArray(), 0);
+        }
 
-        internal virtual uint ReadU32() => BitConverter.ToUInt32(ReadBytes(sizeof(int)).Reverse().ToArray());
+        internal virtual uint ReadU32()
+        {
+            return BitConverter.ToUInt32(ReadBytes(sizeof(int)).Reverse().ToArray(), 0);
+        }
 
-        internal virtual ulong ReadU64() => BitConverter.ToUInt64(ReadBytes(sizeof(long)).Reverse().ToArray());
+        internal virtual ulong ReadU64()
+        {
+            return BitConverter.ToUInt64(ReadBytes(sizeof(long)).Reverse().ToArray(), 0);
+        }
 
         internal void Pad()
         {
@@ -65,10 +119,25 @@ namespace kbinxmlcs
                 Buffer.Add(0);
         }
 
-        internal byte[] ToArray() => Buffer.ToArray();
+        internal byte[] ToArray()
+        {
+            return Buffer.ToArray();
+        }
 
-        internal int Length => Buffer.Count();
+        internal long Length
+        {
+            get
+            {
+                return Buffer.Count();
+            }
+        }
 
-        internal byte this[int index] => Buffer[index];
+        internal byte this[int index]
+        {
+            get
+            {
+                return Buffer[index];
+            }
+        }
     }
 }

--- a/kbinxmlcs/Converters.cs
+++ b/kbinxmlcs/Converters.cs
@@ -24,14 +24,14 @@ namespace kbinxmlcs
 
         public static string U8ToString(byte[] bytes) => bytes[0].ToString();
         public static string S8ToString(byte[] bytes) => ((sbyte)bytes[0]).ToString();
-        public static string U16ToString(byte[] bytes) => BitConverter.ToUInt16(bytes.Reverse().ToArray()).ToString();
-        public static string S16ToString(byte[] bytes) => BitConverter.ToInt16(bytes.Reverse().ToArray()).ToString();
-        public static string U32ToString(byte[] bytes) => BitConverter.ToUInt32(bytes.Reverse().ToArray()).ToString();
-        public static string S32ToString(byte[] bytes) => BitConverter.ToInt32(bytes.Reverse().ToArray()).ToString();
-        public static string U64ToString(byte[] bytes) => BitConverter.ToUInt64(bytes.Reverse().ToArray()).ToString();
-        public static string S64ToString(byte[] bytes) => BitConverter.ToInt64(bytes.Reverse().ToArray()).ToString();
+        public static string U16ToString(byte[] bytes) => BitConverter.ToUInt16(bytes.Reverse().ToArray(), 0).ToString();
+        public static string S16ToString(byte[] bytes) => BitConverter.ToInt16(bytes.Reverse().ToArray(), 0).ToString();
+        public static string U32ToString(byte[] bytes) => BitConverter.ToUInt32(bytes.Reverse().ToArray(), 0).ToString();
+        public static string S32ToString(byte[] bytes) => BitConverter.ToInt32(bytes.Reverse().ToArray(), 0).ToString();
+        public static string U64ToString(byte[] bytes) => BitConverter.ToUInt64(bytes.Reverse().ToArray(), 0).ToString();
+        public static string S64ToString(byte[] bytes) => BitConverter.ToInt64(bytes.Reverse().ToArray(), 0).ToString();
         public static string Ip4ToString(byte[] buffer) => new IPAddress(buffer).ToString();
-        public static string SingleToString(byte[] buffer) => BitConverter.ToSingle(buffer.Reverse().ToArray()).ToString("0.000000");
-        public static string DoubleToString(byte[] buffer) => BitConverter.ToDouble(buffer.Reverse().ToArray()).ToString("0.000000");
+        public static string SingleToString(byte[] buffer) => BitConverter.ToSingle(buffer.Reverse().ToArray(), 0).ToString("0.000000");
+        public static string DoubleToString(byte[] buffer) => BitConverter.ToDouble(buffer.Reverse().ToArray(), 0).ToString("0.000000");
     }
 }

--- a/kbinxmlcs/DataBuffer.cs
+++ b/kbinxmlcs/DataBuffer.cs
@@ -13,12 +13,15 @@ namespace kbinxmlcs
 
         internal DataBuffer(byte[] buffer, Encoding encoding)
         {
+            isRead = true;
+            Buffer_ro = buffer;
             Buffer = buffer.ToList();
             _encoding = encoding;
         }
 
         internal DataBuffer(Encoding encoding)
         {
+            isRead = false;
             _encoding = encoding;
         }
 
@@ -33,7 +36,16 @@ namespace kbinxmlcs
 
         internal byte[] Read32BitAligned(int count)
         {
-            byte[] result = Buffer.Skip(_pos32).Take(count).ToArray();
+            byte[] result;
+            if (isRead)
+            {
+                result = new byte[count];
+                System.Buffer.BlockCopy(Buffer_ro, _pos32, result, 0, count);
+            }
+            else
+            {
+                result = Buffer.Skip(_pos32).Take(count).ToArray();
+            }
             while (count % 4 != 0)
                 count++;
             _pos32 += count;
@@ -48,7 +60,7 @@ namespace kbinxmlcs
             if (_pos16 % 4 == 0)
                 _pos32 += 4;
 
-            byte[] result = Buffer.Skip(_pos16).Take(2).ToArray();
+            byte[] result = new byte[] { Buffer[_pos16], Buffer[_pos16 + 1] };
             _pos16 += 2;
             Realign16_8();
 
@@ -60,7 +72,7 @@ namespace kbinxmlcs
             if (_pos8 % 4 == 0)
                 _pos32 += 4;
 
-            byte[] result = Buffer.Skip(_pos8).Take(1).ToArray();
+            byte[] result = new byte[] { Buffer[_pos8] };
             _pos8++;
             Realign16_8();
 

--- a/kbinxmlcs/NodeBuffer.cs
+++ b/kbinxmlcs/NodeBuffer.cs
@@ -42,7 +42,7 @@ namespace kbinxmlcs
             if (_compressed)
                 return Sixbit.Decode(ReadBytes((int)Math.Ceiling(length * 6 / 8.0)), length);
             
-            return _encoding.GetString(ReadBytes((length & 0b10111111) + 1));
+            return _encoding.GetString(ReadBytes((length & 0xBF) + 1));
         }
     }
 }

--- a/kbinxmlcs/XmlReader.cs
+++ b/kbinxmlcs/XmlReader.cs
@@ -44,7 +44,7 @@ namespace kbinxmlcs
             var nodeLength = binaryBuffer.ReadS32();
             _nodeBuffer = new NodeBuffer(buffer.Skip(8).Take(nodeLength).ToArray(), compressed, encoding);
 
-            var dataLength = BitConverter.ToInt32(buffer.Skip(nodeLength + 8).Take(4).Reverse().ToArray());
+            var dataLength = BitConverter.ToInt32(buffer.Skip(nodeLength + 8).Take(4).Reverse().ToArray(), 0);
             _dataBuffer = new DataBuffer(buffer.Skip(nodeLength + 12).Take(dataLength).ToArray(), encoding);
 
             _xmlDocument.InsertBefore(_xmlDocument.CreateXmlDeclaration("1.0", encoding.WebName, null), _xmlDocument.DocumentElement);
@@ -63,6 +63,7 @@ namespace kbinxmlcs
                 //Array flag is on the second bit
                 var array = (nodeType & 64) > 0;
                 nodeType = (byte)(nodeType & ~64);
+                NodeType propertyType;
 
                 if (Enum.IsDefined(typeof(ControlType), nodeType))
                 {
@@ -96,7 +97,7 @@ namespace kbinxmlcs
                             return _xmlDocument;
                     }
                 }
-                else if (TypeDictionary.TypeMap.TryGetValue(nodeType, out var propertyType))
+                else if (TypeDictionary.TypeMap.TryGetValue(nodeType, out propertyType))
                 {
                     var elementName = _nodeBuffer.ReadString();
                     _currentElement = (XmlElement)_currentElement.AppendChild(_xmlDocument.CreateElement(elementName));
@@ -129,7 +130,7 @@ namespace kbinxmlcs
                         for (var i = 0; i < arraySize / propertyType.Size; i++)
                             result.Add(propertyType.ToString(buffer.Skip(i * propertyType.Size)
                                 .Take(propertyType.Size).ToArray()));
-                        _currentElement.InnerText = string.Join(' ', result);
+                        _currentElement.InnerText = string.Join(" ", result);
                         
                     }
                 }

--- a/kbinxmlcs/XmlWriter.cs
+++ b/kbinxmlcs/XmlWriter.cs
@@ -119,7 +119,7 @@ namespace kbinxmlcs
                 if (childNode is XmlElement)
                     Recurse((XmlElement)childNode);
             }
-            _nodeBuffer.WriteU8(0xBE);
+            _nodeBuffer.WriteU8(0xFE);
         }
     }
 }


### PR DESCRIPTION
Hi, 
Thanks for this handy konami xml decoder/encoder lib, I've used it in my own project `Sound Voltex ULtimate Nemsys Unlocker` ( codename `sdvx-proxy`), which is a MitM proxy server using [WinDivert](https://reqrypt.org/windivert.html) to modify network traffic, in order to do as its name - unlock all nemsys crews. 

Alongside using the lib, I made a few changes and would like to create this PR. 
Main changes are: 
- Changed those lambda expressions to regular function ( since I only installed VS2015 )
- Changed the array end byte in XmlWriter to 0xFE ( or it's actually incorrect format )
- Seperated BinaryBuffer to `readonly` and `readwrite` types, because using `List.Skip(offset).Take(count)` is really slow when doing a lot. My test result is that 50k of binary can use up to 15s to decode, and 150k binary will take up a whole minute. After this change they take respectively 400ms and 3s. 